### PR TITLE
Support aws-sdk-go-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This package provides simple `http.Client` creation that wraps all outgoing HTTP
 ## Requirements
 
 In order to use signing graciously provided by [@nicolai86](https://github.com/nikolai86) in the AWS SDK for Go, you must be using a version that has been updated since the merge of [pull request #735](https://github.com/aws/aws-sdk-go/pull/735) for the SDK (tagged release v1.2.0).
+Additionally, you may use the v2 sdk: [https://github.com/aws/aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2).
 
 ## Acknowledgements
 
@@ -45,6 +46,21 @@ var credentials *credentials.Credentials
 // ... set credentials ...
 var signer = v4.NewSigner(credentials)
 
-// *v4.Signer, *http.Client, AWS service abbreviation, AWS region
+// aws_signing_client.AWSSigner, *http.Client, AWS service abbreviation, AWS region
 var awsClient = aws_signing_client.New(signer, nil, "es", "us-east-1")
+```
+
+## v2 aws sdk
+
+Using aws sdk v2 is as simple as changing the package and configuring with `CredentialsProvider`.
+
+```go
+import (
+	"https://github.com/aws/aws-sdk-go-v2/aws"
+	"https://github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+)
+
+var credsProvider aws.CredentialsProvider
+// ... set credentials ...
+var signer = v4.NewSigner(credsProvider)
 ```

--- a/client.go
+++ b/client.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/aws/aws-sdk-go/private/protocol/rest"
 )
 
 type AWSSigner interface {
@@ -87,7 +85,7 @@ func (s *Signer) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.URL.Scheme = "https"
 	if strings.Contains(req.URL.RawPath, "%2C") {
 		s.logger.Printf("Escaping path for URL path '%s'", req.URL.RawPath)
-		req.URL.RawPath = rest.EscapePath(req.URL.RawPath, false)
+		req.URL.RawPath = escapePath(req.URL.RawPath, false)
 	}
 	t := time.Now()
 	req.Header.Set("Date", t.Format(time.RFC3339))

--- a/escape_path.go
+++ b/escape_path.go
@@ -1,0 +1,37 @@
+package aws_signing_client
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Whether the byte value can be sent without escaping in AWS URLs
+var noEscape [256]bool
+
+func init() {
+	for i := 0; i < len(noEscape); i++ {
+		// AWS expects every character except these to be escaped
+		noEscape[i] = (i >= 'A' && i <= 'Z') ||
+			(i >= 'a' && i <= 'z') ||
+			(i >= '0' && i <= '9') ||
+			i == '-' ||
+			i == '.' ||
+			i == '_' ||
+			i == '~'
+	}
+}
+
+// NOTE: This was lifted from aws-sdk to remove package dependency
+// escapePath escapes part of a URL path in Amazon style
+func escapePath(path string, encodeSep bool) string {
+	var buf bytes.Buffer
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if noEscape[c] || (c == '/' && !encodeSep) {
+			buf.WriteByte(c)
+		} else {
+			fmt.Fprintf(&buf, "%%%02X", c)
+		}
+	}
+	return buf.String()
+}


### PR DESCRIPTION
AWS announced the developer preview of v2: https://github.com/aws/aws-sdk-go-v2.

This PR stubs out the signing interface so that this library isn't bound to a specific golang package.