### PR TITLE
Use a new default http client instead of the singleton

### DIFF
--- a/client.go
+++ b/client.go
@@ -53,7 +53,7 @@ func New(v4s *v4.Signer, client *http.Client, service string, region string) (*h
 	case region == "":
 		return nil, MissingRegionError{}
 	case c == nil:
-		c = http.DefaultClient
+		c = &http.Client{}
 	}
 	s := &Signer{
 		transport: c.Transport,


### PR DESCRIPTION
The docs for `New` indicate that if you pass in `nil` for the client, a new client will be created.  However, in practice, the client is set to the http.DefaultClient which is a singleton to be shared with any other uses of the base `http` methods like `http.Get`.  

I believe the intention was to create a new empty client vs. using the DefaultClient which is global state used by other http library methods.